### PR TITLE
Add API endpoint to list cache keys with pattern filtering

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -215,6 +215,7 @@ The application uses environment variables for configuration with comprehensive 
 - **/health**: Health check with detailed system status
 - **/metrics**: Prometheus-compatible metrics
 - **/api/cache**: Cache management (clear, stats)
+- **/api/cache/keys**: List all cache keys with optional pattern filtering
 - **/api/cache/url-transform**: URL transformation cache management
 - **/api/domains**: Domain configuration management
 - **/api/file-resolution**: File resolution system management

--- a/docs/api-documentation.md
+++ b/docs/api-documentation.md
@@ -189,6 +189,98 @@ curl -X GET http://localhost:3000/api/cache/stats
 }
 ```
 
+### GET /api/cache/keys
+
+Returns all cache keys from each of the application's caches with optional pattern filtering.
+
+**Request (All Keys):**
+
+```bash
+curl -X GET http://localhost:3000/api/cache/keys
+```
+
+**Request (With Pattern Filter):**
+
+```bash
+curl -X GET "http://localhost:3000/api/cache/keys?pattern=*ddt.com*"
+```
+
+**Request (With Wildcard Pattern):**
+
+```bash
+curl -X GET "http://localhost:3000/api/cache/keys?pattern=GET:*:/images/*"
+```
+
+**Response:**
+
+```json
+{
+  "success": true,
+  "message": "Cache keys retrieved successfully",
+  "data": {
+    "caches": {
+      "main": [
+        "GET:ddt.com:/about:transformed=/ddt/about:target=main--allaboutv2--ddttom.hlx.live",
+        "GET:blog.allabout.network:/posts:transformed=/blog/posts:target=main--allaboutv2--ddttom.hlx.live",
+        "GET:allabout.network:/images/logo.png"
+      ],
+      "urlTransform": [
+        "transform:ddt.com:https://main--allaboutv2--ddttom.hlx.live/ddt/about",
+        "transform:blog.allabout.network:https://main--allaboutv2--ddttom.hlx.live/blog/posts"
+      ],
+      "fileResolution": [
+        "file:docs.example.com:/getting-started:md,html,txt",
+        "file:api.example.com:/v1/users:json,xml"
+      ]
+    },
+    "summary": {
+      "main": 3,
+      "urlTransform": 2,
+      "fileResolution": 2,
+      "total": 7
+    },
+    "timestamp": "2024-01-15T10:30:00.000Z"
+  }
+}
+```
+
+**Response (With Pattern Filter):**
+
+```json
+{
+  "success": true,
+  "message": "Cache keys retrieved successfully",
+  "data": {
+    "caches": {
+      "main": [
+        "GET:ddt.com:/about:transformed=/ddt/about:target=main--allaboutv2--ddttom.hlx.live"
+      ],
+      "urlTransform": [
+        "transform:ddt.com:https://main--allaboutv2--ddttom.hlx.live/ddt/about"
+      ],
+      "fileResolution": []
+    },
+    "summary": {
+      "main": 1,
+      "urlTransform": 1,
+      "fileResolution": 0,
+      "total": 2
+    },
+    "timestamp": "2024-01-15T10:30:00.000Z"
+  }
+}
+```
+
+**Query Parameters:**
+
+- `pattern` (optional): Pattern to filter cache keys. Supports wildcards (`*`) and exact matches.
+
+**Cache Types:**
+
+- `main`: General response cache with domain and path transformation information
+- `urlTransform`: URL transformation cache for rewritten URLs
+- `fileResolution`: File resolution cache for extensionless file lookups
+
 ### DELETE /api/cache
 
 Purges cache entries with optional pattern matching and domain filtering.

--- a/src/cache/cache-manager.js
+++ b/src/cache/cache-manager.js
@@ -361,6 +361,40 @@ class CacheManager {
   }
   
   /**
+   * Get all cache keys
+   * @param {String} pattern - Optional pattern to filter keys
+   * @returns {Array} Array of cache keys
+   */
+  getKeys(pattern = null) {
+    if (!this.enabled) return [];
+    
+    try {
+      const keys = this.cache.keys();
+      
+      if (!pattern) {
+        return keys;
+      }
+      
+      // Apply pattern filtering if specified
+      return keys.filter(key => {
+        if (pattern === '*') {
+          return true;
+        } else if (pattern.includes('*')) {
+          // Convert glob pattern to regex
+          const regexPattern = new RegExp('^' + pattern.replace(/\*/g, '.*') + '$');
+          return regexPattern.test(key);
+        } else {
+          return key.includes(pattern);
+        }
+      });
+    } catch (err) {
+      this.stats.errors++;
+      logger.error(`Cache keys retrieval error: ${err.message}`);
+      return [];
+    }
+  }
+
+  /**
    * Get cache statistics
    * @returns {Object} Cache statistics
    */

--- a/src/cache/file-resolution-cache.js
+++ b/src/cache/file-resolution-cache.js
@@ -380,6 +380,41 @@ class FileResolutionCache extends EventEmitter {
     }
     
     /**
+     * Get all cache keys
+     * @param {string} pattern - Optional pattern to filter keys
+     * @returns {Array} Array of cache keys
+     */
+    getKeys(pattern = null) {
+        if (!this.config.enabled) {
+            return [];
+        }
+        
+        try {
+            const keys = Array.from(this.cache.keys());
+            
+            if (!pattern) {
+                return keys;
+            }
+            
+            // Apply pattern filtering if specified
+            return keys.filter(key => {
+                if (pattern === '*') {
+                    return true;
+                } else if (pattern.includes('*')) {
+                    // Convert glob pattern to regex
+                    const regexPattern = new RegExp('^' + pattern.replace(/\*/g, '.*') + '$');
+                    return regexPattern.test(key);
+                } else {
+                    return key.includes(pattern);
+                }
+            });
+        } catch (err) {
+            logger.error(`File resolution cache keys retrieval error: ${err.message}`);
+            return [];
+        }
+    }
+
+    /**
      * Get cache entries for debugging
      * @param {number} limit - Maximum number of entries to return
      * @returns {Array} Array of cache entries


### PR DESCRIPTION
## Summary
- Introduces a new API endpoint `/api/cache/keys` to list all cache keys across multiple caches
- Supports optional pattern filtering with wildcard (`*`) support for flexible key retrieval
- Enhances cache manager and file resolution cache with `getKeys` methods for key listing
- Provides detailed response including keys per cache, summary counts, and error reporting

## Changes

### API
- Added GET `/api/cache/keys` endpoint in `src/app.js`:
  - Retrieves keys from main cache, URL transformation cache, and file resolution cache
  - Supports query parameter `pattern` for filtering keys
  - Returns a structured JSON response with keys grouped by cache type and summary statistics
  - Handles partial failures gracefully with multi-status (207) response

### Cache Manager
- Implemented `getKeys(pattern)` method in `src/cache/cache-manager.js`:
  - Returns all keys or filtered keys based on pattern
  - Supports wildcard pattern matching using regex

### File Resolution Cache
- Added `getKeys(pattern)` method in `src/cache/file-resolution-cache.js` with similar filtering logic

### Documentation
- Updated `docs/api-documentation.md` with detailed API usage examples and response formats
- Added reference to new endpoint in `CLAUDE.md`

## Test plan
- [x] Verify `/api/cache/keys` returns all keys without filter
- [x] Verify pattern filtering works with exact and wildcard patterns
- [x] Confirm response structure includes keys, summary, timestamp, and error details if any
- [x] Test partial failure scenarios by simulating cache errors
- [x] Check logs for appropriate error and info messages during key retrieval

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/2effbba9-fa92-4f4f-bedf-ada69977eadc

## Summary by Sourcery

Implement a new GET /api/cache/keys API endpoint for listing all cache keys across main, URL transformation, and file resolution caches with optional wildcard pattern filtering, aggregated summary, and error handling.

New Features:
- Add GET /api/cache/keys endpoint to retrieve keys from main, URL transformation, and file resolution caches
- Implement getKeys(pattern) method in CacheManager to list and optionally filter cache keys
- Implement getKeys(pattern) method in FileResolutionCache to list and optionally filter cache keys

Enhancements:
- Return HTTP 207 Multi-Status when some cache key retrievals fail to indicate partial success

Documentation:
- Update API documentation and CLAUDE.md with usage details for the new /api/cache/keys endpoint